### PR TITLE
making sure complexity thresholds are always arrays

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,6 +14,15 @@ function complexity(options){
 		breakOnErrors: true
 	}, options);
 
+	// always making sure threasholds are arrays
+	if( !Array.isArray( options.cyclomatic ) ) {
+		options.cyclomatic = [ options.cyclomatic ];
+	}
+
+	if( !Array.isArray( options.halstead ) ) {
+		options.halstead = [ options.halstead ];
+	}
+
 	var files = [];
 	var errorCount = 0;
 


### PR DESCRIPTION
We use numeric values for thresholds, so figured this would be a good update for this plugin
