### PR TITLE
Skip Empty Files

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,8 +46,13 @@ function complexity(options){
 		}));
 
 		files.forEach(function(file){
+			var contents = file.contents.toString();			
+			if (contents.length === 0) {
+				// skip empty file and continue
+				return;
+			}
 			var base = path.relative(file.cwd, file.path);
-			var report = cr.run(file.contents.toString(), options);
+			var report = cr.run(contents, options);
 
 			errorCount += report.functions.filter(function(data){
 				return (data.complexity.cyclomatic > options.cyclomatic[0]) || (data.complexity.halstead.difficulty > options.halstead[0]);

--- a/index.js
+++ b/index.js
@@ -45,14 +45,11 @@ function complexity(options){
 			return path.relative(file.cwd, file.path);
 		}));
 
-		files.forEach(function(file){
-			var contents = file.contents.toString();			
-			if (contents.length === 0) {
-				// skip empty file and continue
-				return;
-			}
+		files.filter(function(file){
+			return file.contents.toString().length > 0;
+		}).forEach(function(file){
 			var base = path.relative(file.cwd, file.path);
-			var report = cr.run(contents, options);
+			var report = cr.run(file.contents.toString(), options);
 
 			errorCount += report.functions.filter(function(data){
 				return (data.complexity.cyclomatic > options.cyclomatic[0]) || (data.complexity.halstead.difficulty > options.halstead[0]);


### PR DESCRIPTION
It's silly that the whole analysis process throws an error and dies if any of the files are empty. This change will simply skip them.