### PR TITLE
Log to console using gulp-util for standardisation

### DIFF
--- a/reporter.js
+++ b/reporter.js
@@ -1,8 +1,9 @@
 /* jshint node:true */
-var multiline, template, reportTemplate, reportFn;
+var multiline, template, reportTemplate, gutil, reportFn;
 
 multiline = require('multiline');
 template = require('string-interpolate');
+gutil = require('gulp-util');
 
 reportTemplate = multiline(function(){/*
 { chalk.styles.yellow.open }{ nope } { path }:{ line } - { name } is too complicated{ chalk.styles.yellow.close }
@@ -38,10 +39,10 @@ exports.log = function(file, report, options, fittedName){
 		};
 	}).forEach(function(report){
 		valid = false;
-		console.log(reportFn(report));
+		gutil.log(reportFn(report));
 	});
 
 	if(valid){
-		console.log(chalk.green('\u2713'), fittedName, helpers.generateBar(report.maintainability, options.maintainability));
+		gutil.log(chalk.green('\u2713'), fittedName, helpers.generateBar(report.maintainability, options.maintainability));
 	}
 };


### PR DESCRIPTION
Just a quick fix to match the output of this plugin to every other gulp plugin i.e.

```
[18:29:58] Using gulpfile ~/Projects/gulp-complexity/gulpfile.js
[18:29:58] Starting 'test'...
✓ reporter.js           ██████ 126.37
✓ reporter-helpers.js   ██████ 135.23
[18:29:58] 'test' finished after 118 ms
```

becomes...

```
[18:29:58] Using gulpfile ~/Projects/gulp-complexity/gulpfile.js
[18:29:58] Starting 'test'...
[18:29:58] ✓ reporter.js           ██████ 126.37
[18:29:58] ✓ reporter-helpers.js   ██████ 135.23
[18:29:58] 'test' finished after 118 ms
```