### PR TITLE
Only display non-errors if verbose option is truthy

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,8 @@ function complexity(options){
 		cyclomatic: [3, 7, 12],
 		halstead: [8, 13, 20],
 		maintainability: 100,
-		breakOnErrors: true
+		breakOnErrors: true,
+		verbose: true
 	}, options);
 
 	// always making sure threasholds are arrays
@@ -48,8 +49,9 @@ function complexity(options){
 		files.filter(function(file){
 			return file.contents.toString().length > 0;
 		}).forEach(function(file){
-			var base = path.relative(file.cwd, file.path);
-			var report = cr.run(file.contents.toString(), options);
+			var base = path.relative(file.cwd, file.path),
+			    report = cr.run(file.contents.toString(), options),
+			    initialErrorCount = errorCount;
 
 			errorCount += report.functions.filter(function(data){
 				return (data.complexity.cyclomatic > options.cyclomatic[0]) || (data.complexity.halstead.difficulty > options.halstead[0]);
@@ -58,7 +60,9 @@ function complexity(options){
 				errorCount++;
 			}
 
-			reporter.log(file, report, options, helpers.fitWhitespace(maxLength, base));
+			if (errorCount != initialErrorCount || options.verbose) {
+				reporter.log(file, report, options, helpers.fitWhitespace(maxLength, base));
+			}
 		});
 
 		if(options.breakOnErrors && errorCount > 0) {


### PR DESCRIPTION
@alexeyraspopov Wondering if you think that this is useful. We're using the tool, but it's a bit noisy with a lot of files and would benefit us if we could have it only log error cases.

Thanks for considering! :)
