### PR TITLE
Adding support for custom reporter

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,8 +3,8 @@ var cr = require('complexity-report'),
 	through = require('through2'),
 	gutil = require('gulp-util'),
 	extend = require('util-extend'),
-	reporter = require('./reporter'),
-	PluginError = gutil.PluginError;
+	PluginError = gutil.PluginError,
+	reporter;
 
 function complexity(options){
 	options = extend({
@@ -12,7 +12,8 @@ function complexity(options){
 		halstead: [8, 13, 20],
 		maintainability: 100,
 		breakOnErrors: true,
-		verbose: true
+		verbose: true,
+		reporter: './reporter'
 	}, options);
 
 	// always making sure threasholds are arrays
@@ -23,6 +24,9 @@ function complexity(options){
 	if(!Array.isArray(options.halstead)){
 		options.halstead = [options.halstead];
 	}
+
+	// Allow for custom reporter
+	reporter = typeof options.reporter === 'string' ? require(options.reporter) : options.reporter;
 
 	var files = [];
 	var errorCount = 0;


### PR DESCRIPTION
Allow the consumer of the gulp task to define their own custom reporter as an option. This will allow either a string or reporter object to be passed in:

```
// Either
{ reporter: path.join(__dirname, 'my-reporter') }

// Or
{ reporter: require('./my-reporter') }
```
